### PR TITLE
feat: add util to normalize user supplied package names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './package'
+export * from './user-input'

--- a/src/user-input.spec.ts
+++ b/src/user-input.spec.ts
@@ -1,0 +1,111 @@
+import { Volume } from 'memfs/lib/volume'
+import { normalizePackages } from './user-input'
+
+describe('normalizePackages', () => {
+  let fs: Volume
+
+  const packageContents = {
+    storageMobile: JSON.stringify({
+      name: '@exodus/storage-mobile',
+    }),
+    config: JSON.stringify({
+      name: '@exodus/config',
+    }),
+    formatting: JSON.stringify({
+      name: '@exodus/formatting',
+    }),
+    theUltimatePackage: JSON.stringify({
+      name: '@exodus/the-ultimate-package',
+    }),
+  }
+  const lernaConfig = JSON.stringify({
+    packages: ['libraries/*', 'modules/*', 'deeply/nested/package/root/*'],
+    version: 'independent',
+    npmClient: 'yarn',
+    useWorkspaces: true,
+    useNx: true,
+  })
+
+  beforeEach(() => {
+    fs = Volume.fromJSON({
+      'lerna.json': lernaConfig,
+      'modules/storage-mobile/package.json': packageContents.storageMobile,
+      'deeply/nested/package/root/the-ultimate-package/package.json':
+        packageContents.theUltimatePackage,
+      'modules/config/package.json': packageContents.config,
+      'libraries/formatting/package.json': packageContents.formatting,
+    })
+  })
+
+  it('should trim spaces', async () => {
+    const result = await normalizePackages({
+      packagesCsv: ' libraries/formatting, modules/config ',
+      filesystem: fs as never,
+    })
+    expect(result).toEqual(['libraries/formatting', 'modules/config'])
+  })
+
+  it('should remove empty values', async () => {
+    const result = await normalizePackages({
+      packagesCsv: ',libraries/formatting, ,modules/config,',
+      filesystem: fs as never,
+    })
+    expect(result).toEqual(['libraries/formatting', 'modules/config'])
+  })
+
+  it('should normalize paths', async () => {
+    const result = await normalizePackages({
+      packagesCsv: 'formatting,config',
+      filesystem: fs as never,
+    })
+    expect(result).toEqual(['libraries/formatting', 'modules/config'])
+  })
+
+  it('should normalize package names', async () => {
+    const result = await normalizePackages({
+      packagesCsv: '@exodus/formatting, @exodus/config ',
+      filesystem: fs as never,
+    })
+    expect(result).toEqual(['libraries/formatting', 'modules/config'])
+  })
+
+  it('should normalize deeply nested package name', async () => {
+    const result = await normalizePackages({
+      packagesCsv: '@exodus/the-ultimate-package',
+      filesystem: fs as never,
+    })
+    expect(result).toEqual(['deeply/nested/package/root/the-ultimate-package'])
+  })
+
+  it('should normalize deeply nested short name', async () => {
+    const result = await normalizePackages({
+      packagesCsv: 'the-ultimate-package',
+      filesystem: fs as never,
+    })
+    expect(result).toEqual(['deeply/nested/package/root/the-ultimate-package'])
+  })
+
+  it('should throw for non existing short names', async () => {
+    const promise = normalizePackages({
+      packagesCsv: 'batcave, formatting',
+      filesystem: fs as never,
+    })
+    await expect(promise).rejects.toThrow()
+  })
+
+  it('should throw for non existing package names', async () => {
+    const promise = normalizePackages({
+      packagesCsv: '@exodus/formatting,@exodus/wayne-enterprises,@exodus/batcave',
+      filesystem: fs as never,
+    })
+    await expect(promise).rejects.toThrow()
+  })
+
+  it('should throw for non existing package roots', async () => {
+    const promise = normalizePackages({
+      packagesCsv: 'packages/formatting,misc/test',
+      filesystem: fs as never,
+    })
+    await expect(promise).rejects.toThrow()
+  })
+})

--- a/src/user-input.ts
+++ b/src/user-input.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { getPackagePathsByFolder } from './package'
+import { Filesystem } from './utils/types'
+
+type Params = {
+  filesystem?: Filesystem
+  packagesCsv: string
+}
+
+type PackagePath = string
+
+export async function normalizePackages({
+  packagesCsv,
+  filesystem = fs,
+}: Params): Promise<PackagePath[]> {
+  const byFolder = await getPackagePathsByFolder({ filesystem })
+
+  const normalized = []
+  const invalid = []
+
+  const packages = packagesCsv.split(',')
+  for (const thePackage of packages) {
+    const trimmed = thePackage.trim()
+    if (trimmed === '') continue
+
+    const folderName = path.basename(trimmed)
+    const packagePath = byFolder[folderName]
+
+    if (!packagePath) {
+      invalid.push(trimmed)
+      continue
+    }
+
+    normalized.push(packagePath)
+  }
+
+  if (invalid.length > 0) {
+    throw new Error(`Encountered invalid package inputs: ${invalid.join(', ')}`)
+  }
+
+  return normalized
+}

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs'
+
 export type LernaConfig = {
   packages?: string[]
 }
@@ -5,3 +7,5 @@ export type LernaConfig = {
 export type PackageJson = {
   name: string
 }
+
+export type Filesystem = typeof fs


### PR DESCRIPTION
## Summary 

Extracts the `normalizePackages` utility from `lerna-release-action`, so it can be used for the script to link hydra packages to mobile.