### PR TITLE
fix: missing package path when specifying root

### DIFF
--- a/src/package.spec.ts
+++ b/src/package.spec.ts
@@ -83,10 +83,13 @@ describe('package', () => {
     })
   })
 
-  const setup = (additionalContents: { [path: string]: string } = {}) => {
+  const setup = (
+    additionalContents: { [path: string]: string } = {},
+    additionalPackages: string[] = []
+  ) => {
     fs = createFsFromJSON({
       'lerna.json': JSON.stringify({
-        packages: ['modules/*', 'libraries/*', 'empty/*'],
+        packages: ['modules/*', 'libraries/*', 'empty/*', ...additionalPackages],
       }),
       'modules/wayne-manor/package.json': JSON.stringify({
         name: '@exodus/wayne-manor',
@@ -116,6 +119,44 @@ describe('package', () => {
       await expect(getPackagePaths({ filesystem: fs as never })).resolves.toEqual([
         'modules/wayne-manor',
         'libraries/wayne-tower',
+      ])
+    })
+
+    it('should return path for a single package root', async () => {
+      setup(
+        {
+          'single/package/package.json': JSON.stringify({
+            name: '@exodus/package',
+          }),
+        },
+        ['single/package', 'groups/{bruce,batman}']
+      )
+
+      await expect(getPackagePaths({ filesystem: fs as never })).resolves.toEqual([
+        'modules/wayne-manor',
+        'libraries/wayne-tower',
+        'single/package',
+      ])
+    })
+
+    it('should return paths for grouped packages', async () => {
+      setup(
+        {
+          'groups/bruce/package.json': JSON.stringify({
+            name: '@exodus/bruce',
+          }),
+          'groups/batman/package.json': JSON.stringify({
+            name: '@exodus/batman',
+          }),
+        },
+        ['groups/{bruce,batman}']
+      )
+
+      await expect(getPackagePaths({ filesystem: fs as never })).resolves.toEqual([
+        'modules/wayne-manor',
+        'libraries/wayne-tower',
+        'groups/bruce',
+        'groups/batman',
       ])
     })
   })

--- a/src/package.ts
+++ b/src/package.ts
@@ -27,7 +27,9 @@ export async function getPackagePaths({ filesystem = fs }: DefaultParams = {}): 
   const packageRoots = await getPackageRoots({ filesystem })
   const paths = await Promise.all(
     packageRoots.map(async (root) => {
-      const folders = await filesystem.promises.readdir(root).catch(() => [])
+      const folders = await filesystem.promises.readdir(root).catch(() => [] as string[])
+      if (folders.includes('package.json')) return root
+
       const filtered = await filterAsync(folders, (folder) =>
         filesystem.promises.stat(path.join(root, folder, 'package.json')).catch(() => false)
       )


### PR DESCRIPTION
Currently when one specifies a single package root in `packages` of `lerna.json`, it is ignored by `getPackagePaths` whereas `getPackageRoots` correctly returns it.

Example of `lerna.json` specifying `single/package/package.json`:
```json
"packages": ["single/package"]
```

With these changes, we no longer ignore the above package and support not only collections but also single packages.

Captured from https://github.com/ExodusMovement/exodus-hydra/issues/1474.