### PR TITLE
chore: remove publish access restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "type": "git",
     "url": "https://github.com/ExodusMovement/lerna-utils.git"
   },
-  "publishConfig": {
-    "access": "restricted"
-  },
   "release": {
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
This removes the publish access restriction. In case we're to open source this on npm, this would make it private again on next publish. Without this setting, it will just keep whatever is on npm

